### PR TITLE
[todo] Implements a formatted tasks list output

### DIFF
--- a/cmd/todo/main.go
+++ b/cmd/todo/main.go
@@ -44,14 +44,12 @@ func (cfg *Config) RegisterFlags(fs *flag.FlagSet) {
 	}
 }
 
-func tasksList(tL todo.Tasks) {
-	if len(tL) == 0 {
+func tasksList(tL *todo.Tasks) {
+	if len(*tL) == 0 {
 		fmt.Println(infoTag, "There are no existing tasks! get to work...")
 		return
 	}
-	for _, t := range tL {
-		fmt.Println(t.Title)
-	}
+	fmt.Print(tL)
 }
 
 func taskAdd(tL *todo.Tasks, title string, dry bool) {
@@ -134,7 +132,7 @@ func main() {
 		taskAdd(tL, cfg.taskTitle, cfg.dryRun)
 
 	default:
-		tasksList(*tL)
+		tasksList(tL)
 	}
 
 	taskSave(tL, cfg.filename, cfg.dryRun)

--- a/cmd/todo/main_test.go
+++ b/cmd/todo/main_test.go
@@ -84,7 +84,8 @@ func TestTodoCLI(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		want := tt + "\n"
+		// Expected format provided by Tasks.String()
+		want := "[X] 1: " + tt + "\n"
 
 		got := string(out)
 		if want != got {

--- a/pkg/todo/todo.go
+++ b/pkg/todo/todo.go
@@ -3,6 +3,7 @@ package todo
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"time"
@@ -89,6 +90,19 @@ func (t *Tasks) Load(filename string) error {
 		return err
 	}
 	return nil
+}
+
+// String prints out a formatted task list. It implements the Stringer interface.
+func (t *Tasks) String() string {
+	formatted := ""
+	for i, t := range *t {
+		prefix := "[ ]"
+		if t.Completed {
+			prefix = "[X]"
+		}
+		formatted += fmt.Sprintf("%s %d: %s\n", prefix, i+1, t.Title)
+	}
+	return formatted
 }
 
 // indexOfTitle returns an index `int` value by searching current Tasks by Task.title.


### PR DESCRIPTION
- Leverages the built-in Stringer interface.
- Updates CLI integration tests to match new output.